### PR TITLE
Feature: 라이브 샘플 크롤링 프로브와 실행 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ANMAWON_TIMEOUT=20
 
 ```bash
 cd apps/crawler
+anmawon-crawler probe-source
 anmawon-crawler crawl
 anmawon-crawler clean
 anmawon-crawler geocode
@@ -100,6 +101,13 @@ anmawon-crawler build-dataset
 
 실제 셀렉터 보정과 주소 보정 규칙은 사이트 HTML을 보면서 추가로 다듬으면 됩니다.
 실사이트 연결이 네트워크 환경에 따라 실패할 수 있으므로, 파서 단위 테스트를 먼저 통과시키고 제한된 범위의 샘플 크롤링으로 검증하는 흐름을 권장합니다.
+샘플 크롤링 전에 `anmawon-crawler probe-source`를 실행하면 DNS, HTTPS, HTTP fallback 상태를 먼저 확인할 수 있습니다.
+HTTPS 연결이 리셋되는 환경에서는 아래처럼 HTTP base URL과 제한된 범위를 사용해 샘플 검증을 시작할 수 있습니다.
+
+```bash
+cd apps/crawler
+ANMAWON_BASE_URL=http://www.anmawon.com anmawon-crawler crawl --area-code 031 --max-pages-per-area 1
+```
 
 ## Team Workflow
 

--- a/apps/crawler/src/anmawon_crawler/cli.py
+++ b/apps/crawler/src/anmawon_crawler/cli.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from .crawler import crawl_directory
 from .geocode import apply_geocoding
 from .normalize import clean_records
+from .probe import format_probe_report, run_source_probe
 from .settings import load_settings
 from .storage import (
     CLEAN_DATA_PATH,
@@ -44,6 +45,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers.add_parser("clean", help="Normalize addresses and text fields")
     subparsers.add_parser("geocode", help="Resolve coordinates with Kakao Local API")
+    subparsers.add_parser(
+        "probe-source",
+        help="Check live source reachability before running crawl",
+    )
     subparsers.add_parser(
         "build-dataset",
         help="Promote the latest processed file to the final dataset",
@@ -94,6 +99,16 @@ def command_geocode() -> None:
     print(f"Wrote {len(geocoded)} records to {GEOCODED_DATA_PATH}")
 
 
+def command_probe_source() -> None:
+    settings = load_settings()
+    results = run_source_probe(
+        base_url=settings.anmawon_base_url,
+        timeout=settings.timeout,
+        user_agent=settings.anmawon_user_agent,
+    )
+    print(format_probe_report(settings.anmawon_base_url, results))
+
+
 def command_build_dataset() -> None:
     source_path = GEOCODED_DATA_PATH if GEOCODED_DATA_PATH.exists() else CLEAN_DATA_PATH
     records = read_dataset(source_path)
@@ -115,6 +130,10 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     if args.command == "geocode":
         command_geocode()
+        return
+
+    if args.command == "probe-source":
+        command_probe_source()
         return
 
     if args.command == "build-dataset":

--- a/apps/crawler/src/anmawon_crawler/probe.py
+++ b/apps/crawler/src/anmawon_crawler/probe.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import asdict, dataclass
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+
+LIST_PATH = "/FindShop/List"
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    target: str
+    ok: bool
+    detail: str
+    status_code: int | None = None
+    final_url: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def build_probe_targets(base_url: str) -> List[tuple[str, str]]:
+    normalized = normalize_base_url(base_url)
+    parsed = urlparse(normalized)
+
+    targets = [("configured-list", urljoin(normalized, LIST_PATH))]
+
+    if parsed.scheme == "https":
+        http_base = parsed._replace(scheme="http").geturl().rstrip("/")
+        targets.append(("http-fallback-list", urljoin(http_base, LIST_PATH)))
+
+    return targets
+
+
+def probe_dns(hostname: str) -> ProbeResult:
+    try:
+        addresses = sorted(
+            {
+                result[4][0]
+                for result in socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+            }
+        )
+    except OSError as error:
+        return ProbeResult(
+            name="dns",
+            target=hostname,
+            ok=False,
+            detail=f"{type(error).__name__}: {error}",
+        )
+
+    return ProbeResult(
+        name="dns",
+        target=hostname,
+        ok=bool(addresses),
+        detail=", ".join(addresses) if addresses else "no addresses returned",
+    )
+
+
+def probe_url(client: httpx.Client, name: str, url: str) -> ProbeResult:
+    try:
+        response = client.get(url)
+    except httpx.HTTPError as error:
+        return ProbeResult(
+            name=name,
+            target=url,
+            ok=False,
+            detail=f"{type(error).__name__}: {error}",
+        )
+
+    return ProbeResult(
+        name=name,
+        target=url,
+        ok=response.is_success,
+        detail=f"HTTP {response.status_code}",
+        status_code=response.status_code,
+        final_url=str(response.url),
+    )
+
+
+def run_source_probe(
+    *,
+    base_url: str,
+    timeout: float,
+    user_agent: str,
+) -> List[ProbeResult]:
+    normalized = normalize_base_url(base_url)
+    hostname = urlparse(normalized).hostname or normalized
+    results = [probe_dns(hostname)]
+
+    headers = {"User-Agent": user_agent}
+    with httpx.Client(timeout=timeout, follow_redirects=True, headers=headers) as client:
+        for name, target in build_probe_targets(normalized):
+            results.append(probe_url(client, name, target))
+
+    return results
+
+
+def format_probe_report(base_url: str, results: List[ProbeResult]) -> str:
+    payload = {
+        "baseUrl": normalize_base_url(base_url),
+        "results": [result.to_dict() for result in results],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)

--- a/apps/crawler/tests/test_probe.py
+++ b/apps/crawler/tests/test_probe.py
@@ -1,0 +1,69 @@
+import json
+import unittest
+
+import httpx
+
+from anmawon_crawler.probe import (
+    build_probe_targets,
+    format_probe_report,
+    probe_url,
+)
+
+
+class BuildProbeTargetsTest(unittest.TestCase):
+    def test_adds_http_fallback_for_https_base_url(self) -> None:
+        self.assertEqual(
+            build_probe_targets("https://www.anmawon.com"),
+            [
+                ("configured-list", "https://www.anmawon.com/FindShop/List"),
+                ("http-fallback-list", "http://www.anmawon.com/FindShop/List"),
+            ],
+        )
+
+    def test_keeps_single_target_for_http_base_url(self) -> None:
+        self.assertEqual(
+            build_probe_targets("http://www.anmawon.com"),
+            [("configured-list", "http://www.anmawon.com/FindShop/List")],
+        )
+
+
+class ProbeUrlTest(unittest.TestCase):
+    def test_reports_http_status(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, request=request)
+            )
+        )
+
+        result = probe_url(client, "configured-list", "https://example.com/FindShop/List")
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.detail, "HTTP 200")
+
+    def test_reports_network_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection reset by peer", request=request)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        result = probe_url(client, "configured-list", "https://example.com/FindShop/List")
+
+        self.assertFalse(result.ok)
+        self.assertIn("ConnectError", result.detail)
+
+
+class FormatProbeReportTest(unittest.TestCase):
+    def test_formats_json_payload(self) -> None:
+        payload = format_probe_report(
+            "https://www.anmawon.com/",
+            [],
+        )
+
+        parsed = json.loads(payload)
+        self.assertEqual(parsed["baseUrl"], "https://www.anmawon.com")
+        self.assertEqual(parsed["results"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/crawling.md
+++ b/docs/crawling.md
@@ -17,8 +17,20 @@
 ## Validation Tips
 
 - 실사이트 연결이 안 되는 환경에서는 먼저 파서 단위 테스트로 셀렉터 로직을 검증합니다.
+- `anmawon-crawler probe-source`로 DNS, HTTPS, HTTP fallback 응답을 먼저 확인합니다.
 - 필요하면 `ANMAWON_BASE_URL`과 `ANMAWON_USER_AGENT`를 환경변수로 조정해 재시도합니다.
 - 샘플 검증은 `--max-pages-per-area` 옵션으로 범위를 제한해 진행합니다.
+
+## Live Sample Example
+
+```bash
+cd apps/crawler
+ANMAWON_BASE_URL=http://www.anmawon.com anmawon-crawler probe-source
+ANMAWON_BASE_URL=http://www.anmawon.com anmawon-crawler crawl --area-code 031 --max-pages-per-area 1
+```
+
+샘플 검증 시에는 먼저 특정 지역 코드 하나와 1페이지 범위로 시작합니다.
+현재 환경에서는 HTTPS가 연결 재설정으로 실패했고, `031` 1페이지 샘플 크롤링으로 raw 데이터 10건을 확인했습니다.
 
 ## Known Follow-up Work
 


### PR DESCRIPTION
### Related Issue 🧵

- Closes #12

---

### Summary 📌

- 실사이트 접근 전에 DNS, HTTPS, HTTP fallback 상태를 확인할 수 있는 `probe-source` 명령을 추가했습니다.
- HTTP fallback 경로를 이용한 샘플 크롤링 가이드를 문서에 반영했고, 실제로 `031` 1페이지 샘플 raw 데이터 10건을 생성해 필수 필드 추출을 확인했습니다.

---

### Task Details 🚩

- [x] `probe-source` CLI 명령을 추가했습니다.
- [x] probe 로직과 출력 포맷을 테스트로 검증했습니다.
- [x] README와 crawling 문서에 라이브 샘플 실행 예시를 추가했습니다.
- [x] `ANMAWON_BASE_URL=http://www.anmawon.com anmawon-crawler crawl --area-code 031 --max-pages-per-area 1`로 샘플 raw 데이터 10건을 확인했습니다.

---

### Validation ✅

- [x] `PYTHONPATH=apps/crawler/src python3 -m unittest discover -s apps/crawler/tests`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] 해당 없음

---

### Review Requirements 💬(Optional)

- 현재 환경에서 기본 HTTPS는 `Connection reset by peer`로 실패하지만, HTTP fallback 경로로는 샘플 검증이 가능했습니다.
- 샘플 raw 데이터는 `data/raw/shops.raw.json`에 생성되며 gitignore 대상이라 PR에는 포함되지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `anmawon-crawler probe-source` command to validate data source connectivity and verify HTTPS/HTTP fallback behavior before running crawl operations.

* **Documentation**
  * Updated crawling guide with probe-source usage instructions and practical examples for diagnosing and resolving connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->