### PR TITLE
Feature: 홈 화면을 서비스용 카피와 정보 구조로 개편

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -94,6 +94,33 @@ code {
   color: var(--ink-muted);
 }
 
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.hero-badges span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  border-radius: 999px;
+  padding: 0 12px;
+  background: rgba(166, 75, 42, 0.08);
+  border: 1px solid rgba(166, 75, 42, 0.12);
+  color: #7a341c;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.hero-status {
+  margin: 16px 0 0;
+  max-width: 60ch;
+  line-height: 1.65;
+  color: var(--ink);
+}
+
 .hero-stats {
   margin: 0;
   display: grid;
@@ -122,6 +149,31 @@ code {
   display: grid;
   gap: 16px;
   grid-template-columns: 2fr 1fr;
+}
+
+.service-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.service-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 250, 241, 0.82);
+  box-shadow: var(--shadow);
+  padding: 18px 20px;
+}
+
+.service-card h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.service-card p {
+  margin: 10px 0 0;
+  line-height: 1.65;
+  color: var(--ink-muted);
 }
 
 .control-card {
@@ -307,6 +359,7 @@ code {
 
 @media (max-width: 1024px) {
   .hero-card,
+  .service-grid,
   .content-grid,
   .control-grid {
     grid-template-columns: 1fr;

--- a/apps/web/src/components/ShopExplorer.tsx
+++ b/apps/web/src/components/ShopExplorer.tsx
@@ -26,6 +26,7 @@ function formatDate(value: string | null): string {
 export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
   const [query, setQuery] = useState("");
   const [areaCode, setAreaCode] = useState("all");
+  const hasDataset = dataset.count > 0;
 
   const areas = Array.from(
     new Set(dataset.shops.map((shop) => shop.areaCode).filter(Boolean))
@@ -59,40 +60,69 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
     (shop) => typeof shop.lat === "number" && typeof shop.lng === "number"
   ).length;
 
+  const emptyMessage = hasDataset
+    ? "조건에 맞는 안마원이 없습니다. 검색어나 지역을 다시 선택해보세요."
+    : "아직 공개용 데이터가 준비 중입니다. 수집이 완료되면 이곳에 안마원 목록이 표시됩니다.";
+
   return (
     <div className="explorer-shell">
       <section className="hero-card">
         <div>
-          <p className="eyebrow">Certified Massage Map</p>
-          <h1>국가 공인 안마원 데이터를 수집하고 지도에 올리는 작업실</h1>
+          <p className="eyebrow">National Certified Massage Map</p>
+          <h1>전국 국가공인 안마원을 지역과 지도에서 찾아보세요</h1>
           <p className="hero-copy">
-            크롤러가 생성한 <code>shops.geo.json</code>을 읽어 목록과 지도를 함께 보여줍니다.
-            현재는 MVP 스캐폴딩이 준비되어 있고, 실제 데이터가 쌓이면 검색과 필터가 바로 작동합니다.
+            국가 공인 안마원 목록을 지역별로 찾고, 지도에서 위치를 확인하고, 상세 페이지로
+            바로 이동할 수 있도록 한곳에 모았습니다.
+          </p>
+          <div className="hero-badges">
+            <span>지역별 검색</span>
+            <span>지도 탐색</span>
+            <span>상세 페이지 연결</span>
+          </div>
+          <p className="hero-status">
+            {hasDataset
+              ? "현재 공개된 데이터 기준으로 검색과 지도 탐색을 바로 이용할 수 있습니다."
+              : "현재는 서비스 화면과 탐색 흐름을 먼저 준비 중이며, 데이터가 들어오면 검색 결과가 함께 표시됩니다."}
           </p>
         </div>
         <dl className="hero-stats">
           <div>
-            <dt>전체 안마원</dt>
+            <dt>등록 안마원</dt>
             <dd>{dataset.count}</dd>
           </div>
           <div>
-            <dt>좌표 확보</dt>
+            <dt>지도 표시 가능</dt>
             <dd>{geocodedCount}</dd>
           </div>
           <div>
-            <dt>데이터 생성</dt>
+            <dt>최근 데이터 갱신</dt>
             <dd>{formatDate(dataset.generatedAt)}</dd>
           </div>
         </dl>
       </section>
 
+      <section className="service-grid">
+        <article className="service-card">
+          <h2>이용 방법</h2>
+          <p>상호명, 주소, 전화번호로 검색하고 원하는 지역을 선택해 안마원을 빠르게 좁혀보세요.</p>
+        </article>
+        <article className="service-card">
+          <h2>확인할 수 있는 정보</h2>
+          <p>주소, 전화번호, 지역 정보와 함께 지도 표시 여부를 확인하고 상세 페이지로 이동할 수 있습니다.</p>
+        </article>
+        <article className="service-card">
+          <h2>데이터 기준</h2>
+          <p>국가 공인 안마원 목록을 바탕으로 정리되며, 수집 시점에 따라 최신 갱신 시각이 함께 표시됩니다.</p>
+        </article>
+      </section>
+
       <section className="control-grid">
         <label className="control-card">
-          <span>상호명 / 주소 검색</span>
+          <span>안마원 이름 / 주소 검색</span>
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="예: 서울, 031-0193, 안마원 이름"
+            placeholder="예: 서울, 경기, 안마원 이름"
           />
         </label>
 
@@ -116,7 +146,7 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
         <div className="panel">
           <div className="panel-header">
             <h2>지도</h2>
-            <p>{filteredShops.length}개 결과</p>
+            <p>검색 결과 {filteredShops.length}곳</p>
           </div>
           <KakaoMap shops={filteredShops} />
         </div>
@@ -124,13 +154,11 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
         <div className="panel">
           <div className="panel-header">
             <h2>목록</h2>
-            <p>
-              좌표 없는 항목도 목록에서는 확인할 수 있습니다.
-            </p>
+            <p>전화번호와 상세 페이지를 함께 확인할 수 있습니다.</p>
           </div>
           <div className="shop-list">
             {filteredShops.length === 0 ? (
-              <div className="empty-list">표시할 안마원이 아직 없습니다.</div>
+              <div className="empty-list">{emptyMessage}</div>
             ) : null}
 
             {filteredShops.map((shop) => (


### PR DESCRIPTION
### Related Issue 🧵

- Closes #7

---

### Summary 📌

- 홈 화면 히어로 카피를 작업실/MVP 톤에서 서비스 소개형 메시지로 개편했습니다.
- 데이터 유무에 따라 상태 안내와 빈 상태 문구가 자연스럽게 바뀌도록 정리했고, 이용 방법/확인 가능한 정보/데이터 기준 안내 카드를 추가했습니다.

---

### Task Details 🚩

- [x] 히어로 섹션 카피를 서비스 관점으로 재작성했습니다.
- [x] 서비스 안내 카드 섹션을 추가했습니다.
- [x] 데이터 유무에 따라 상태 안내 문구와 빈 상태 메시지를 분기했습니다.
- [x] 기존 반응형 grid 구조를 유지하면서 모바일에서도 자연스럽게 보이도록 정리했습니다.

---

### Validation ✅

- [x] `PYTHONPATH=apps/crawler/src python3 -m unittest discover -s apps/crawler/tests`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] 해당 없음

---

### Review Requirements 💬(Optional)

- 기능 동작보다는 첫 화면의 이해도와 안내 흐름 개선에 초점을 둔 PR입니다.
- 데이터 구조는 건드리지 않았고, 메시지와 정보 구조만 서비스형으로 정리했습니다.