### PR TITLE
Feature: 목록과 지도 상호작용 강화

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -353,6 +353,11 @@ code {
   gap: 14px;
 }
 
+.shop-card-selected {
+  border-color: rgba(166, 75, 42, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(166, 75, 42, 0.18);
+}
+
 .shop-card-top {
   display: flex;
   justify-content: space-between;
@@ -401,6 +406,36 @@ code {
 .shop-meta dd {
   margin: 0;
   text-align: right;
+}
+
+.shop-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.select-link {
+  min-height: 38px;
+  border: 1px solid rgba(91, 63, 35, 0.14);
+  border-radius: 999px;
+  padding: 0 14px;
+  background: var(--surface-strong);
+  color: var(--ink);
+  font-size: 0.92rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.select-link-active {
+  border-color: rgba(166, 75, 42, 0.3);
+  background: rgba(166, 75, 42, 0.1);
+  color: #7a341c;
+}
+
+.shop-note {
+  color: var(--ink-muted);
+  font-size: 0.9rem;
 }
 
 .detail-link {

--- a/apps/web/src/components/KakaoMap.tsx
+++ b/apps/web/src/components/KakaoMap.tsx
@@ -69,10 +69,20 @@ function loadKakaoSdk(appKey: string): Promise<void> {
   });
 }
 
-export function KakaoMap({ shops }: { shops: Shop[] }) {
+export function KakaoMap({
+  shops,
+  selectedShopId,
+  onSelectShop
+}: {
+  shops: Shop[];
+  selectedShopId: string | null;
+  onSelectShop?: (shopId: string) => void;
+}) {
   const appKey = process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY;
   const mapRef = useRef<any>(null);
-  const markersRef = useRef<any[]>([]);
+  const markersRef = useRef<
+    Array<{ shopId: string; marker: any; infoWindow: any }>
+  >([]);
   const [sdkReady, setSdkReady] = useState(false);
   const [sdkError, setSdkError] = useState<string | null>(null);
 
@@ -122,8 +132,9 @@ export function KakaoMap({ shops }: { shops: Shop[] }) {
       });
     }
 
-    for (const marker of markersRef.current) {
-      marker.setMap(null);
+    for (const entry of markersRef.current) {
+      entry.infoWindow.close();
+      entry.marker.setMap(null);
     }
 
     markersRef.current = [];
@@ -147,13 +158,43 @@ export function KakaoMap({ shops }: { shops: Shop[] }) {
       marker.setMap(mapRef.current);
       window.kakao.maps.event.addListener(marker, "click", () => {
         infoWindow.open(mapRef.current, marker);
+        onSelectShop?.(shop.shopId);
       });
       bounds.extend(position);
-      markersRef.current.push(marker);
+      markersRef.current.push({
+        shopId: shop.shopId,
+        marker,
+        infoWindow
+      });
     }
 
     mapRef.current.setBounds(bounds);
-  }, [sdkReady, shops]);
+  }, [onSelectShop, sdkReady, shops]);
+
+  useEffect(() => {
+    if (!sdkReady || !window.kakao?.maps || !mapRef.current) {
+      return;
+    }
+
+    for (const entry of markersRef.current) {
+      entry.infoWindow.close();
+    }
+
+    if (!selectedShopId) {
+      return;
+    }
+
+    const selectedEntry = markersRef.current.find(
+      (entry) => entry.shopId === selectedShopId
+    );
+
+    if (!selectedEntry) {
+      return;
+    }
+
+    selectedEntry.infoWindow.open(mapRef.current, selectedEntry.marker);
+    mapRef.current.panTo(selectedEntry.marker.getPosition());
+  }, [sdkReady, selectedShopId]);
 
   if (!appKey) {
     return (

--- a/apps/web/src/components/ShopExplorer.tsx
+++ b/apps/web/src/components/ShopExplorer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { KakaoMap } from "@/components/KakaoMap";
 import { getAreaFilterLabel, getAreaLabel } from "@/lib/regions";
@@ -26,6 +26,7 @@ function formatDate(value: string | null): string {
 export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
   const [query, setQuery] = useState("");
   const [areaCode, setAreaCode] = useState("all");
+  const [selectedShopId, setSelectedShopId] = useState<string | null>(null);
   const hasDataset = dataset.count > 0;
   const trimmedQuery = query.trim();
 
@@ -60,6 +61,12 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
   const geocodedCount = dataset.shops.filter(
     (shop) => typeof shop.lat === "number" && typeof shop.lng === "number"
   ).length;
+  const selectedShop =
+    filteredShops.find((shop) => shop.shopId === selectedShopId) ?? null;
+  const selectedShopHasCoordinates =
+    !!selectedShop &&
+    typeof selectedShop.lat === "number" &&
+    typeof selectedShop.lng === "number";
   const hasActiveFilters = areaCode !== "all" || trimmedQuery.length > 0;
   const selectedAreaLabel = areaCode === "all" ? "전체 지역" : getAreaFilterLabel(areaCode);
 
@@ -71,6 +78,21 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
     setQuery("");
     setAreaCode("all");
   }
+
+  useEffect(() => {
+    if (filteredShops.length === 0) {
+      setSelectedShopId(null);
+      return;
+    }
+
+    const stillVisible = filteredShops.some((shop) => shop.shopId === selectedShopId);
+
+    if (stillVisible) {
+      return;
+    }
+
+    setSelectedShopId(filteredShops[0].shopId);
+  }, [filteredShops, selectedShopId]);
 
   return (
     <div className="explorer-shell">
@@ -181,9 +203,19 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
         <div className="panel">
           <div className="panel-header">
             <h2>지도</h2>
-            <p>검색 결과 {filteredShops.length}곳</p>
+            <p>
+              {selectedShop
+                ? selectedShopHasCoordinates
+                  ? `${selectedShop.name || "선택된 안마원"} 위치를 지도에서 확인 중입니다.`
+                  : `${selectedShop.name || "선택된 안마원"}은 아직 좌표가 없어 목록에서만 확인할 수 있습니다.`
+                : `검색 결과 ${filteredShops.length}곳`}
+            </p>
           </div>
-          <KakaoMap shops={filteredShops} />
+          <KakaoMap
+            shops={filteredShops}
+            selectedShopId={selectedShopId}
+            onSelectShop={setSelectedShopId}
+          />
         </div>
 
         <div className="panel">
@@ -200,39 +232,60 @@ export function ShopExplorer({ dataset }: { dataset: ShopDataset }) {
               <div className="empty-list">{emptyMessage}</div>
             ) : null}
 
-            {filteredShops.map((shop) => (
-              <article key={shop.shopId} className="shop-card">
-                <div className="shop-card-top">
-                  <div>
-                    <h3>{shop.name || "이름 미상"}</h3>
-                    <p>{shop.addressNormalized || shop.addressRaw || "주소 미상"}</p>
-                  </div>
-                  <span className="shop-chip">{getAreaLabel(shop.areaCode)}</span>
-                </div>
-                <dl className="shop-meta">
-                  <div>
-                    <dt>전화</dt>
-                    <dd>{shop.phone || "없음"}</dd>
-                  </div>
-                  <div>
-                    <dt>shopId</dt>
-                    <dd>{shop.shopId}</dd>
-                  </div>
-                  <div>
-                    <dt>지오코딩</dt>
-                    <dd>{shop.geocodeStatus}</dd>
-                  </div>
-                </dl>
-                <a
-                  href={shop.detailUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="detail-link"
+            {filteredShops.map((shop) => {
+              const isSelected = shop.shopId === selectedShopId;
+              const hasCoordinates =
+                typeof shop.lat === "number" && typeof shop.lng === "number";
+
+              return (
+                <article
+                  key={shop.shopId}
+                  className={`shop-card${isSelected ? " shop-card-selected" : ""}`}
                 >
-                  상세 페이지 열기
-                </a>
-              </article>
-            ))}
+                  <div className="shop-card-top">
+                    <div>
+                      <h3>{shop.name || "이름 미상"}</h3>
+                      <p>{shop.addressNormalized || shop.addressRaw || "주소 미상"}</p>
+                    </div>
+                    <span className="shop-chip">{getAreaLabel(shop.areaCode)}</span>
+                  </div>
+                  <dl className="shop-meta">
+                    <div>
+                      <dt>전화</dt>
+                      <dd>{shop.phone || "없음"}</dd>
+                    </div>
+                    <div>
+                      <dt>shopId</dt>
+                      <dd>{shop.shopId}</dd>
+                    </div>
+                    <div>
+                      <dt>지오코딩</dt>
+                      <dd>{shop.geocodeStatus}</dd>
+                    </div>
+                  </dl>
+                  <div className="shop-actions">
+                    <button
+                      type="button"
+                      className={`select-link${isSelected ? " select-link-active" : ""}`}
+                      onClick={() => setSelectedShopId(shop.shopId)}
+                    >
+                      {hasCoordinates ? "지도에서 보기" : "목록에서 보기"}
+                    </button>
+                    {!hasCoordinates ? (
+                      <span className="shop-note">좌표 준비 중</span>
+                    ) : null}
+                  </div>
+                  <a
+                    href={shop.detailUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="detail-link"
+                  >
+                    상세 페이지 열기
+                  </a>
+                </article>
+              );
+            })}
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Related Issue 🧵

- Closes #9

---

### Summary 📌

- 목록과 지도가 같은 선택 상태를 공유하도록 연결했습니다.
- 사용자가 리스트와 마커를 오가며 특정 안마원을 더 자연스럽게 확인할 수 있어야 해서 필요했습니다.

---

### Task Details 🚩

- [x] 선택된 안마원 상태를 `ShopExplorer`에서 관리하고 목록과 지도에 전달했습니다.
- [x] 목록 버튼과 지도 마커 클릭을 서로 연동하고, 좌표가 없는 항목은 안내 문구로 처리했습니다.
- [x] 선택 상태에 맞는 카드 강조와 지도 패널 설명 문구를 추가했습니다.

---

### Validation ✅

- [x] `PYTHONPATH=apps/crawler/src python3 -m unittest discover -s apps/crawler/tests`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] 해당 없음

---

### Review Requirements 💬(Optional)

- 카카오 지도 키와 실제 geocoded 데이터가 들어온 뒤 선택된 마커 강조 경험이 기대한 흐름으로 보이는지만 한 번 더 봐주시면 좋습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive shop selection synced between list and map; selecting a shop highlights it and the map pans to its marker.
  * Map can be driven by external selection and notifies the list when a marker is chosen.
  * Selection clears or resets intelligently when filters change.

* **Style**
  * New visual styles for selected shop cards, pill-style select controls, action layout, and muted shop notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->