### PR TITLE
BugFix: 지역 코드 및 페이지 자동 발견 로직 안정화

### DIFF
--- a/apps/crawler/src/anmawon_crawler/crawler.py
+++ b/apps/crawler/src/anmawon_crawler/crawler.py
@@ -26,8 +26,13 @@ ADDRESS_KEYS = ("주소", "소재지", "도로명주소")
 PHONE_KEYS = ("전화번호", "전화", "연락처", "대표번호")
 
 PHONE_PATTERN = re.compile(r"0\d{1,2}-\d{3,4}-\d{4}")
+AREA_CODE_PATTERN = re.compile(r"^\d{2,3}$")
 ADDRESS_HINT_PATTERN = re.compile(
     r"(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)"
+)
+PAGE_VALUE_PATTERN = re.compile(
+    r"(?:[?&]page=|(?:go|move|fnMove)Page\(|['\"]page['\"]\s*[:=]\s*['\"]?)(\d+)",
+    re.IGNORECASE,
 )
 
 
@@ -68,20 +73,33 @@ def extract_query_values(text: str, key: str) -> List[str]:
     return sorted(values)
 
 
+def is_valid_area_code(value: str) -> bool:
+    return bool(AREA_CODE_PATTERN.fullmatch(value))
+
+
+def extract_page_values(text: str) -> List[int]:
+    values = {int(value) for value in extract_query_values(text, "page") if value.isdigit()}
+    values.update(int(match.group(1)) for match in PAGE_VALUE_PATTERN.finditer(text))
+    return sorted(values)
+
+
 def discover_area_codes(soup: BeautifulSoup) -> List[str]:
     area_codes: Set[str] = set()
 
-    for anchor in soup.select("a[href]"):
+    for anchor in soup.select("a[href], a[onclick]"):
         href = anchor.get("href", "")
         area_codes.update(extract_query_values(href, "SearchArea"))
+        onclick = anchor.get("onclick", "")
+        area_codes.update(extract_query_values(onclick, "SearchArea"))
 
-    for option in soup.select("option[value]"):
+    for option in soup.select("option[value], option[onclick]"):
         value = option.get("value", "")
         area_codes.update(extract_query_values(value, "SearchArea"))
-        if value.isdigit():
+        area_codes.update(extract_query_values(option.get("onclick", ""), "SearchArea"))
+        if is_valid_area_code(value):
             area_codes.add(value)
 
-    return sorted(code for code in area_codes if code)
+    return sorted(code for code in area_codes if is_valid_area_code(code))
 
 
 def discover_page_count(soup: BeautifulSoup) -> int:
@@ -89,9 +107,12 @@ def discover_page_count(soup: BeautifulSoup) -> int:
 
     for anchor in soup.select("a[href]"):
         href = anchor.get("href", "")
-        for value in extract_query_values(href, "page"):
-            if value.isdigit():
-                pages.add(int(value))
+        if DETAIL_PATH not in href:
+            pages.update(extract_page_values(href))
+        pages.update(extract_page_values(anchor.get("onclick", "")))
+
+    for element in soup.select("[onclick]"):
+        pages.update(extract_page_values(element.get("onclick", "")))
 
     return max(pages)
 

--- a/apps/crawler/tests/test_crawler.py
+++ b/apps/crawler/tests/test_crawler.py
@@ -46,16 +46,19 @@ class ListParsingTest(unittest.TestCase):
               <body>
                 <a href="/FindShop/List?SearchArea=031">031</a>
                 <a href="/FindShop/List?SearchArea=02&page=2">02</a>
+                <a onclick="location.href='/FindShop/List?SearchArea=064'">제주</a>
                 <select>
                   <option value="051">부산</option>
                   <option value="/FindShop/List?SearchArea=031">경기</option>
+                  <option value="">전지역</option>
+                  <option value="1">=선택=</option>
                 </select>
               </body>
             </html>
             """
         )
 
-        self.assertEqual(discover_area_codes(soup), ["02", "031", "051"])
+        self.assertEqual(discover_area_codes(soup), ["02", "031", "051", "064"])
 
     def test_discovers_highest_page_number(self) -> None:
         soup = soup_from_html(
@@ -65,12 +68,27 @@ class ListParsingTest(unittest.TestCase):
                 <a href="/FindShop/List?page=1">1</a>
                 <a href="/FindShop/List?page=4">4</a>
                 <a href="/FindShop/List?page=12">12</a>
+                <button onclick="goPage(9)">9</button>
               </body>
             </html>
             """
         )
 
         self.assertEqual(discover_page_count(soup), 12)
+
+    def test_ignores_detail_page_params_when_counting_pages(self) -> None:
+        soup = soup_from_html(
+            """
+            <html>
+              <body>
+                <a href="/FindShop/Detail?page=77&shopId=031-0193">상세</a>
+                <a href="/FindShop/List?page=3">3</a>
+              </body>
+            </html>
+            """
+        )
+
+        self.assertEqual(discover_page_count(soup), 3)
 
     def test_extracts_unique_absolute_detail_urls(self) -> None:
         soup = soup_from_html(


### PR DESCRIPTION
### Related Issue 🧵

- Closes #2

---

### Summary 📌

- 지역 코드 자동 발견에서 placeholder 값이 섞이는 경우를 걸러내고, 자바스크립트 기반 페이지 이동도 인식하도록 보강했습니다.
- 상세 링크의 `page` 파라미터를 페이지네이션으로 오인하면 수집 범위가 흔들릴 수 있어서, 목록 페이지 수 계산 기준을 더 엄격하게 만들 필요가 있었습니다.

---

### Task Details 🚩

- [x] 지역 코드 자동 발견에서 유효한 2~3자리 코드만 남기도록 필터링했습니다.
- [x] `onclick` 기반 `goPage(...)` 같은 자바스크립트 페이지 이동도 페이지 수 계산에 반영했습니다.
- [x] 상세 링크의 `page` 파라미터는 페이지네이션 계산에서 제외하도록 보정했습니다.
- [x] 대표 HTML 패턴을 재현하는 crawler 테스트를 추가했습니다.

---

### Validation ✅

- [x] `PYTHONPATH=apps/crawler/src python3 -m unittest discover -s apps/crawler/tests`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] 해당 없음

---

### Review Requirements 💬(Optional)

- 실사이트 목록 페이지가 `href`와 `onclick`을 혼용하는 케이스에서 이번 보강 범위가 충분한지만 한 번 더 봐주시면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced extraction of area codes with validation to ensure accuracy
  * Expanded page number detection across multiple navigation sources
  * Improved discovery of administrative areas from additional HTML elements

* **Tests**
  * Updated test coverage to validate area code and page number extraction enhancements
  * Added test for proper handling of list versus detail page parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->